### PR TITLE
Moved scene code out of physics initialization.

### DIFF
--- a/Federation/Federates/CraterTransport/src/CraterTransport.cpp
+++ b/Federation/Federates/CraterTransport/src/CraterTransport.cpp
@@ -12,11 +12,13 @@ int main(void) {
     // Creates federation if this is the first federate connected,
     // connects to existing federation otherwise
     HlaWorldPtr hlaWorld = HlaWorld::Factory::create();
-    Physics::CraterTransport_Physics* physicsManager = new Physics::CraterTransport_Physics();
+    Physics::PhysicsManager* physicsManager = new Physics::PhysicsManager();
 
     if (!physicsManager->initPhysics()) {
         return -1;
     }
+
+    physicsManager->loadSampleScene();
 
     try {
         hlaWorld->connect();

--- a/Federation/Federates/CraterTransport/src/CraterTransport_Physics.cpp
+++ b/Federation/Federates/CraterTransport/src/CraterTransport_Physics.cpp
@@ -19,12 +19,14 @@ namespace Physics {
             return false;
         }
 
+        // OmniPvd only works in debug mode
         #if _DEBUG
         gOmniPvd = OmniPvd::initOmniPvd(*gFoundation);
         #endif
 
         gPhysics = PxCreatePhysics(PX_PHYSICS_VERSION, *gFoundation, PxTolerancesScale(), true, 0, gOmniPvd);
 
+        // OmniPvd only works in debug mode
         #if _DEBUG
         if (gPhysics->getOmniPvd()) {
             gPhysics->getOmniPvd()->startSampling();
@@ -54,8 +56,8 @@ namespace Physics {
         defaultActor = createDynamic(PxTransform(PxVec3(0, 40, 100)), PxSphereGeometry(10), PxVec3(0, -50, -100));
     }
 
-    void PhysicsManager::simulateStep() {
-        gScene->simulate(1.0f / 60.0f);
+    void PhysicsManager::simulateStep(double timeStep) {
+        gScene->simulate(timeStep);
         gScene->fetchResults(true);
     }
 
@@ -64,6 +66,7 @@ namespace Physics {
         PX_RELEASE(gDispatcher);
         PX_RELEASE(gPhysics);
         PX_RELEASE(gFoundation);
+        PX_RELEASE(gOmniPvd);
 
         printf("Simulation Complete\n");
     }
@@ -76,6 +79,8 @@ namespace Physics {
         return dynamic;
     }
 
+
+    // Getters
     const PxDefaultAllocator PhysicsManager::getAllocator() {
         return gAllocator;
     }

--- a/Federation/Federates/CraterTransport/src/CraterTransport_Physics.cpp
+++ b/Federation/Federates/CraterTransport/src/CraterTransport_Physics.cpp
@@ -3,24 +3,15 @@
 #include <iostream>
 
 namespace Physics {
-    PxDefaultAllocator       CraterTransport_Physics::gAllocator;
-    PxDefaultErrorCallback   CraterTransport_Physics::gErrorCallback;
-    PxFoundation*            CraterTransport_Physics::gFoundation = nullptr;
-    PxPhysics*               CraterTransport_Physics::gPhysics = nullptr;
-    PxDefaultCpuDispatcher*  CraterTransport_Physics::gDispatcher = nullptr;
-    PxScene*                 CraterTransport_Physics::gScene = nullptr;
-    PxMaterial*              CraterTransport_Physics::gMaterial = nullptr;
-    PxOmniPvd*               CraterTransport_Physics::gOmniPvd = nullptr;
-
-    CraterTransport_Physics::CraterTransport_Physics() {
+    PhysicsManager::PhysicsManager() {
 
     }
 
-    CraterTransport_Physics::~CraterTransport_Physics() {
+    PhysicsManager::~PhysicsManager() {
 
     }
 
-    bool CraterTransport_Physics::initPhysics() {
+    bool PhysicsManager::initPhysics() {
         gFoundation = PxCreateFoundation(PX_PHYSICS_VERSION, gAllocator, gErrorCallback);
 
         if (!gFoundation) {
@@ -43,7 +34,11 @@ namespace Physics {
             return false;
         }
         #endif
+        
+        return true;
+    }
 
+    void PhysicsManager::loadSampleScene() {
         PxSceneDesc sceneDesc(gPhysics->getTolerancesScale());
         sceneDesc.gravity = PxVec3(0.0f, -1.62f, 0.0f);
         gDispatcher = PxDefaultCpuDispatcherCreate(2);
@@ -57,18 +52,14 @@ namespace Physics {
         gScene->addActor(*groundPlane);
 
         defaultActor = createDynamic(PxTransform(PxVec3(0, 40, 100)), PxSphereGeometry(10), PxVec3(0, -50, -100));
-
-        return true;
     }
 
-    void CraterTransport_Physics::simulateStep() {
+    void PhysicsManager::simulateStep() {
         gScene->simulate(1.0f / 60.0f);
         gScene->fetchResults(true);
-        PxVec3 velocity = defaultActor->getLinearVelocity();
-        std::cout << velocity.y << std::endl;
     }
 
-    void CraterTransport_Physics::cleanupPhysics() {
+    void PhysicsManager::cleanupPhysics() {
         PX_RELEASE(gScene);
         PX_RELEASE(gDispatcher);
         PX_RELEASE(gPhysics);
@@ -77,11 +68,47 @@ namespace Physics {
         printf("Simulation Complete\n");
     }
 
-    PxRigidDynamic* CraterTransport_Physics::createDynamic(const PxTransform& t, const PxGeometry& geometry, const PxVec3& velocity) {
+    PxRigidDynamic* PhysicsManager::createDynamic(const PxTransform& t, const PxGeometry& geometry, const PxVec3& velocity) {
         PxRigidDynamic* dynamic = PxCreateDynamic(*gPhysics, t, geometry, *gMaterial, 10.0f);
         dynamic->setAngularDamping(0.5f);
         dynamic->setLinearVelocity(velocity);
         gScene->addActor(*dynamic);
         return dynamic;
+    }
+
+    const PxDefaultAllocator PhysicsManager::getAllocator() {
+        return gAllocator;
+    }
+
+    const PxDefaultErrorCallback PhysicsManager::getErrorCallback() {
+        return gErrorCallback;
+    }
+
+    const PxFoundation* PhysicsManager::getFoundation() {
+        return gFoundation;
+    }
+
+    const PxPhysics* PhysicsManager::getPhysics() {
+        return gPhysics;
+    }
+
+    const PxDefaultCpuDispatcher* PhysicsManager::getCpuDispatcher() {
+        return gDispatcher;
+    }
+
+    const PxScene* PhysicsManager::getScene() {
+        return gScene;
+    }
+
+    const PxMaterial* PhysicsManager::getMaterial() {
+        return gMaterial;
+    }
+
+    const PxOmniPvd* PhysicsManager::getOmniPvd() {
+        return gOmniPvd;
+    }
+
+    const char* PhysicsManager::getOmniPvdPath() {
+        return gOmniPvdPath;
     }
 }

--- a/Federation/Federates/CraterTransport/src/CraterTransport_Physics.h
+++ b/Federation/Federates/CraterTransport/src/CraterTransport_Physics.h
@@ -9,26 +9,38 @@
 using namespace physx;
 
 namespace Physics {
-    class CraterTransport_Physics {
+    class PhysicsManager {
     public:
-        CraterTransport_Physics();
-        ~CraterTransport_Physics();
+        PhysicsManager();
+        ~PhysicsManager();
         bool initPhysics();
         void simulateStep();
         void cleanupPhysics();
+        void loadSampleScene();
 
-        static PxRigidDynamic* createDynamic(const PxTransform& t, const PxGeometry& geometry, const PxVec3& velocity = PxVec3(0));
+        // getters
+        const PxDefaultAllocator getAllocator();
+        const PxDefaultErrorCallback getErrorCallback();
+        const PxFoundation* getFoundation();
+        const PxPhysics* getPhysics();
+        const PxDefaultCpuDispatcher* getCpuDispatcher();
+        const PxScene* getScene();
+        const PxMaterial* getMaterial();
+        const PxOmniPvd* getOmniPvd();
+        const char* getOmniPvdPath();
+
+        PxRigidDynamic* createDynamic(const PxTransform& t, const PxGeometry& geometry, const PxVec3& velocity = PxVec3(0));
     private:
-        PxRigidDynamic* defaultActor = nullptr;
-        static PxDefaultAllocator       gAllocator;
-        static PxDefaultErrorCallback   gErrorCallback;
-        static PxFoundation*            gFoundation;
-        static PxPhysics*               gPhysics;
-        static PxDefaultCpuDispatcher*  gDispatcher;
-        static PxScene*                 gScene;
-        static PxMaterial*              gMaterial;
-        static PxOmniPvd*               gOmniPvd;
-        const char*                     gOmniPvdPath = NULL;
+        PxDefaultAllocator       gAllocator;
+        PxDefaultErrorCallback   gErrorCallback;
+        PxRigidDynamic*          defaultActor = nullptr;
+        PxFoundation*            gFoundation = nullptr;
+        PxPhysics*               gPhysics = nullptr;
+        PxDefaultCpuDispatcher*  gDispatcher = nullptr;
+        PxScene*                 gScene = nullptr;
+        PxMaterial*              gMaterial = nullptr;
+        PxOmniPvd*               gOmniPvd = nullptr;
+        const char*              gOmniPvdPath = nullptr;
     };
 }
 #endif

--- a/Federation/Federates/CraterTransport/src/CraterTransport_Physics.h
+++ b/Federation/Federates/CraterTransport/src/CraterTransport_Physics.h
@@ -8,17 +8,29 @@
 
 using namespace physx;
 
+// Holds most of the PhysX simulation information
 namespace Physics {
     class PhysicsManager {
     public:
+        // Default constructor
         PhysicsManager();
+
+        // Default destructor
         ~PhysicsManager();
+
+        // Initlializes physics variables
         bool initPhysics();
-        void simulateStep();
+
+        // Moves simulation forward a specified time-step default 60fps
+        void simulateStep(double timeStep = 1.0f / 60.0f);
+
+        // Cleans up physics variables
         void cleanupPhysics();
+
+        // Loads a sample scene for debugging
         void loadSampleScene();
 
-        // getters
+        // Getters
         const PxDefaultAllocator getAllocator();
         const PxDefaultErrorCallback getErrorCallback();
         const PxFoundation* getFoundation();


### PR DESCRIPTION
- Moved the sample scene setup code out of physics initialization because it didn't belong in `initPhysics()` which is meant for variable initialization.
- This also allows us to add more scenes without running into merge conflicts or having to overwrite different scenes in order to get things working.
- TODO: Add user input asking which scene they want to load up (default right now is sample scene).