### PR TITLE
Model loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ CMakeCache.txt
 
 # Models
 *.obj
-
+*.mtl

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ CMakeCache.txt
 # PhysX
 *.ovd
 
+# Models
+*.obj
+

--- a/Federation/Federates/CraterTransport/CMakeLists.txt
+++ b/Federation/Federates/CraterTransport/CMakeLists.txt
@@ -7,12 +7,14 @@ add_executable(${TARGET_NAME}
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/sim_utils.cpp" 
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/sim_utils.h" 
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/OmniPvd.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/ModelLoader.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/src/ModelLoader.cpp"
 )
 
 target_include_directories(${TARGET_NAME}
 	PUBLIC
-	"${CMAKE_SOURCE_DIR}/include"
 	"${CMAKE_SOURCE_DIR}/include/PhysX"
+	"${CMAKE_SOURCE_DIR}/include"
 )
 
 set(PHYSX_LIBS_DEBUG

--- a/Federation/Federates/CraterTransport/src/ModelLoader.cpp
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.cpp
@@ -1,0 +1,94 @@
+#include "ModelLoader.h"
+
+PxTriangleMesh* ModelLoader::loadCraterMesh(PxPhysics* gPhysics) {
+    loadOBJ();
+
+    cout << "Loading .obj into PhysX...\n";
+
+    meshDesc.points.count = vecv.size();
+    meshDesc.points.data = vecv.data();
+    meshDesc.points.stride = sizeof(PxVec3);
+    meshDesc.triangles.data = vecf.data();
+    meshDesc.triangles.stride = 3 * sizeof(unsigned);
+
+    PxTolerancesScale scale;
+    PxCookingParams params(scale);
+
+    params.midphaseDesc = PxMeshMidPhase::eBVH33;
+    params.suppressTriangleMeshRemapTable = true;
+    params.meshPreprocessParams |= PxMeshPreprocessingFlag::eDISABLE_CLEAN_MESH;
+    params.meshPreprocessParams |= PxMeshPreprocessingFlag::eDISABLE_ACTIVE_EDGES_PRECOMPUTE;
+    params.midphaseDesc.mBVH33Desc.meshSizePerformanceTradeOff = 0.55f;
+
+    #if defined(PX_CHECKED) || defined(PX_DEBUG)
+    PX_ASSERT(PxValidateTriangleMesh(params, meshDesc));
+    #endif
+
+    PxTriangleMesh* triMesh = NULL;
+    PxU32 meshSize = 0;
+
+    triMesh = PxCreateTriangleMesh(params, meshDesc, gPhysics->getPhysicsInsertionCallback());
+    cout << "Finished loading .obj into PhysX.\n";
+    return triMesh;
+}
+
+bool ModelLoader::loadOBJ() {
+    ifstream inFile;
+
+    inFile.open("C:\\UCF\\Senior Design\\Simulations\\Models\\Terrain\\84 South Project V2\\84S\\84SMosaic_Punchout_100mpp.obj");
+
+    char buffer[512];
+    string line;
+    
+    if (getline(inFile, line)) {
+        cout << "successfully opened .obj file" << endl;
+    }
+    else {
+        cout << "failed to read file" << endl;
+    }
+
+    cout << "Reading .obj file...\n";
+    while (!inFile.eof()) {
+        getline(inFile, line);
+        stringstream ss(line);
+        PxVec3 v;
+        string s;
+        vector<unsigned> f;
+        ss >> s;
+
+        if (s == "v") {
+            ss >> v[0] >> v[1] >> v[2];
+            vecv.push_back(v);
+        }
+        else if (s == "vn") {
+            ss >> v[0] >> v[1] >> v[2];
+            vecn.push_back(v);
+        }
+        else if (s == "f") {
+            vector<unsigned> temp(9, 0);
+            char* stemp;
+
+            for (int i = 0; i < 3; ++i) {
+                ss >> s;
+                stemp = (char*)s.c_str();
+                stemp = strtok(stemp, "/");
+
+                int ctr = 0;
+                while (stemp != NULL) {
+                    temp[i * 3 + ctr] = atoi(stemp);
+                    stemp = strtok(NULL, "/");
+                    ++ctr;
+                }
+            }
+
+            vecf.push_back(temp);
+        }
+    }
+
+    inFile.close();
+    cout << "final vertex count: " << vecv.size() << endl;
+    cout << "final normal count: " << vecn.size() << endl;
+    cout << "final face count: "   << vecf.size() << endl;
+    cout << "Finished reading .obj\n";
+    return true;
+}

--- a/Federation/Federates/CraterTransport/src/ModelLoader.cpp
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.cpp
@@ -26,7 +26,7 @@ PxTriangleMesh* ModelLoader::loadCraterMesh(PxPhysics* gPhysics) {
     // but it runs into an index out of bounds error that I can't locate
     // the source of. vecv.size() works but with errors in the final look
     // of the mesh.
-    meshDesc.triangles.count = vecv.size();
+    meshDesc.triangles.count = vecf.size() / 3;
     meshDesc.triangles.data = vecf.begin();
     meshDesc.triangles.stride = 3 * sizeof(PxU32);
     
@@ -148,14 +148,13 @@ PxTriangleMesh* ModelLoader::loadSampleCubeMesh(PxPhysics* gPhysics) {
     return gPhysics->createTriangleMesh(readBuffer);
 }
 
-
 // Parses .obj and loads it into two arrays
 bool ModelLoader::loadOBJ() {
     ifstream inFile;
 
     // Put this model in a folder titled "Models" in the base
     // of the repository.
-    inFile.open("../../../Models/AmundsenRim_100mpp.obj");
+    inFile.open("../../../Models/AmundsenRim_100mpp_triangulated.obj");
 
     string line;
     if (getline(inFile, line)) {
@@ -188,11 +187,14 @@ bool ModelLoader::loadOBJ() {
                 ss >> s;
                 stemp = (char*)s.c_str();
                 stemp = strtok(stemp, "/");
-                vecf.pushBack(atoi(stemp));
+                vecf.pushBack(atoi(stemp) - 1);
             }
         }
     }
     inFile.close();
+
+    cout << "Final vecv size: " << vecv.size() << endl;
+    cout << "Final vecf size: " << vecf.size() << endl;
 
     cout << "Finished reading .obj\n\n";
     return true;

--- a/Federation/Federates/CraterTransport/src/ModelLoader.cpp
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.cpp
@@ -1,7 +1,18 @@
 #include "ModelLoader.h"
 
 PxTriangleMesh* ModelLoader::loadCraterMesh(PxPhysics* gPhysics) {
-    if (!loadOBJ()) {
+    bool status;
+
+    // Attempt to open the specified crater mesh file
+    if (fileExists("../../../Models/AmundsenRim_100mpp.obj")) {
+        status = loadOBJ();
+    }
+    else {
+        cout << "Couldn't open crater model, loading sample cube mesh instead.\n\n";
+        return loadSampleCubeMesh(gPhysics);
+    }
+
+    if (!status) {
         return NULL;
     }
 
@@ -36,20 +47,20 @@ PxTriangleMesh* ModelLoader::loadCraterMesh(PxPhysics* gPhysics) {
 
     PxDefaultMemoryOutputStream writeBuffer;
     PxTriangleMeshCookingResult::Enum result;
-    bool status = PxCookTriangleMesh(params, meshDesc, writeBuffer, &result);
+    status = PxCookTriangleMesh(params, meshDesc, writeBuffer, &result);
     if (!status) {
         cout << "Failed to create triangle mesh.\n";
         return nullptr;
     }
 
     PxDefaultMemoryInputData readBuffer(writeBuffer.getData(), writeBuffer.getSize());
-    cout << "Finished loading .obj into PhysX.\n";
+    cout << "Finished loading .obj into PhysX.\n\n";
     return gPhysics->createTriangleMesh(readBuffer);
 }
 
 // Loading a sample cube I used to understand how PxMesh creation works
 PxTriangleMesh* ModelLoader::loadSampleCubeMesh(PxPhysics* gPhysics) {
-    cout << "Loading .obj into PhysX...\n";
+    cout << "Loading .obj into PhysX...\n\n";
 
     unsigned int indices[12][3] = {
         //Top
@@ -128,12 +139,12 @@ PxTriangleMesh* ModelLoader::loadSampleCubeMesh(PxPhysics* gPhysics) {
     PxTriangleMeshCookingResult::Enum result;
     bool status = PxCookTriangleMesh(params, meshDesc, writeBuffer, &result);
     if (!status) {
-        cout << "Failed to create triangle mesh.\n";
+        cout << "Failed to create triangle mesh.\n\n";
         return nullptr;
     }
 
     PxDefaultMemoryInputData readBuffer(writeBuffer.getData(), writeBuffer.getSize());
-    cout << "Finished loading .obj into PhysX.\n";
+    cout << "Finished loading .obj into PhysX.\n\n";
     return gPhysics->createTriangleMesh(readBuffer);
 }
 
@@ -148,14 +159,14 @@ bool ModelLoader::loadOBJ() {
 
     string line;
     if (getline(inFile, line)) {
-        cout << "successfully opened .obj file" << endl;
+        cout << "successfully opened .obj file\n\n";
     }
     else {
-        cout << "failed to read file" << endl;
+        cout << "failed to read file\n\n";
         return false;
     }
 
-    cout << "Reading .obj file...\n";
+    cout << "Reading .obj file...\n\n";
     while (!inFile.eof()) {
         getline(inFile, line);
         stringstream ss(line);
@@ -183,6 +194,11 @@ bool ModelLoader::loadOBJ() {
     }
     inFile.close();
 
-    cout << "Finished reading .obj\n";
+    cout << "Finished reading .obj\n\n";
     return true;
+}
+
+// Returns true if file exists using the specified filepath
+bool ModelLoader::fileExists(const std::string& name) {
+    return ifstream(name).good();
 }

--- a/Federation/Federates/CraterTransport/src/ModelLoader.cpp
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.cpp
@@ -51,7 +51,7 @@ bool ModelLoader::loadOBJ() {
     while (!inFile.eof()) {
         getline(inFile, line);
         stringstream ss(line);
-        PxVec3 v;
+        PxVec3d v;
         string s;
         vector<unsigned> f;
         ss >> s;
@@ -70,6 +70,7 @@ bool ModelLoader::loadOBJ() {
 
             for (int i = 0; i < 3; ++i) {
                 ss >> s;
+                // cout << s << endl;
                 stemp = (char*)s.c_str();
                 stemp = strtok(stemp, "/");
 
@@ -77,7 +78,7 @@ bool ModelLoader::loadOBJ() {
                 while (stemp != NULL) {
                     temp[i * 3 + ctr] = atoi(stemp);
                     stemp = strtok(NULL, "/");
-                    ++ctr;
+                    ctr += 2;
                 }
             }
 
@@ -89,6 +90,7 @@ bool ModelLoader::loadOBJ() {
     cout << "final vertex count: " << vecv.size() << endl;
     cout << "final normal count: " << vecn.size() << endl;
     cout << "final face count: "   << vecf.size() << endl;
+
     cout << "Finished reading .obj\n";
     return true;
 }

--- a/Federation/Federates/CraterTransport/src/ModelLoader.cpp
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.cpp
@@ -1,95 +1,187 @@
 #include "ModelLoader.h"
 
 PxTriangleMesh* ModelLoader::loadCraterMesh(PxPhysics* gPhysics) {
-    loadOBJ();
+    if (!loadOBJ()) {
+        return NULL;
+    }
 
     cout << "Loading .obj into PhysX...\n";
 
     meshDesc.points.count = vecv.size();
-    meshDesc.points.data = vecv.data();
+    meshDesc.points.data = reinterpret_cast<const PxVec3*>(&vecv[0][0]);
     meshDesc.points.stride = sizeof(PxVec3);
-    meshDesc.triangles.data = vecf.data();
-    meshDesc.triangles.stride = 3 * sizeof(unsigned);
 
+    // Error here: Seems to me that the count should be vecf.size()
+    // but it runs into an index out of bounds error that I can't locate
+    // the source of. vecv.size() works but with errors in the final look
+    // of the mesh.
+    meshDesc.triangles.count = vecv.size();
+    meshDesc.triangles.data = vecf.begin();
+    meshDesc.triangles.stride = 3 * sizeof(PxU32);
+    
+    
     PxTolerancesScale scale;
     PxCookingParams params(scale);
 
     params.midphaseDesc = PxMeshMidPhase::eBVH33;
     params.suppressTriangleMeshRemapTable = true;
-    params.meshPreprocessParams |= PxMeshPreprocessingFlag::eDISABLE_CLEAN_MESH;
-    params.meshPreprocessParams |= PxMeshPreprocessingFlag::eDISABLE_ACTIVE_EDGES_PRECOMPUTE;
+
+    params.meshPreprocessParams &= PxMeshPreprocessingFlag::eDISABLE_CLEAN_MESH;
+    params.meshPreprocessParams &= PxMeshPreprocessingFlag::eDISABLE_ACTIVE_EDGES_PRECOMPUTE;
     params.midphaseDesc.mBVH33Desc.meshSizePerformanceTradeOff = 0.55f;
 
     #if defined(PX_CHECKED) || defined(PX_DEBUG)
     PX_ASSERT(PxValidateTriangleMesh(params, meshDesc));
     #endif
 
-    PxTriangleMesh* triMesh = NULL;
-    PxU32 meshSize = 0;
+    PxDefaultMemoryOutputStream writeBuffer;
+    PxTriangleMeshCookingResult::Enum result;
+    bool status = PxCookTriangleMesh(params, meshDesc, writeBuffer, &result);
+    if (!status) {
+        cout << "Failed to create triangle mesh.\n";
+        return nullptr;
+    }
 
-    triMesh = PxCreateTriangleMesh(params, meshDesc, gPhysics->getPhysicsInsertionCallback());
+    PxDefaultMemoryInputData readBuffer(writeBuffer.getData(), writeBuffer.getSize());
     cout << "Finished loading .obj into PhysX.\n";
-    return triMesh;
+    return gPhysics->createTriangleMesh(readBuffer);
 }
 
+// Loading a sample cube I used to understand how PxMesh creation works
+PxTriangleMesh* ModelLoader::loadSampleCubeMesh(PxPhysics* gPhysics) {
+    cout << "Loading .obj into PhysX...\n";
+
+    unsigned int indices[12][3] = {
+        //Top
+        {2, 6, 7 },
+        {2, 3, 7 },
+
+        //Bottom
+        {0, 4, 5 },
+        {0, 1, 5 },
+
+        //Left
+        {0, 2, 6 },
+        {0, 4, 6 },
+
+        //Right
+        {1, 3, 7 },
+        {1, 5, 7 },
+
+        //Front
+        {0, 2, 3 },
+        {0, 1, 3 },
+
+        //Back
+        {4, 6, 7 },
+        {4, 5, 7 }
+    };
+
+    PxArray<PxU32> PxIndices;
+    for (int i = 0; i < 12; ++i) {
+        PxIndices.pushBack(indices[i][0]);
+        PxIndices.pushBack(indices[i][1]);
+        PxIndices.pushBack(indices[i][2]);
+    }
+
+    float vertices[8][3] = {
+        {-1, -1,  0.5}, //0
+        {1, -1,  0.5 }, //1
+        { -1,  1,  0.5}, //2
+        {1,  1,  0.5 }, //3
+        {-1, -1, -0.5 }, //4
+        {1, -1, -0.5 }, //5
+        {-1,  1, -0.5 }, //6
+        {1,  1, -0.5 }  //7
+    };
+
+    PxArray<PxVec3> PxVertices;
+    for (int i = 0; i < 8; ++i) {
+        PxVec3 temp;
+        temp.x = vertices[i][0];
+        temp.y = vertices[i][1];
+        temp.z = vertices[i][2];
+        PxVertices.pushBack(temp);
+    }
+
+    meshDesc.points.count = 8;
+    meshDesc.points.data = reinterpret_cast<const PxVec3*>(&PxVertices[0][0]);
+    meshDesc.points.stride = sizeof(PxVec3);
+    meshDesc.triangles.count = 12;
+    meshDesc.triangles.data = PxIndices.begin();
+    meshDesc.triangles.stride = 3 * sizeof(PxU32);
+
+    PxTolerancesScale scale;
+    PxCookingParams params(scale);
+
+    params.midphaseDesc = PxMeshMidPhase::eBVH33;
+    params.suppressTriangleMeshRemapTable = true;
+    params.meshPreprocessParams &= PxMeshPreprocessingFlag::eDISABLE_CLEAN_MESH;
+    params.meshPreprocessParams &= PxMeshPreprocessingFlag::eDISABLE_ACTIVE_EDGES_PRECOMPUTE;
+    params.midphaseDesc.mBVH33Desc.meshSizePerformanceTradeOff = 0.55f;
+
+    #if defined(PX_CHECKED) || defined(PX_DEBUG)
+    PX_ASSERT(PxValidateTriangleMesh(params, meshDesc));
+    #endif
+
+    PxDefaultMemoryOutputStream writeBuffer;
+    PxTriangleMeshCookingResult::Enum result;
+    bool status = PxCookTriangleMesh(params, meshDesc, writeBuffer, &result);
+    if (!status) {
+        cout << "Failed to create triangle mesh.\n";
+        return nullptr;
+    }
+
+    PxDefaultMemoryInputData readBuffer(writeBuffer.getData(), writeBuffer.getSize());
+    cout << "Finished loading .obj into PhysX.\n";
+    return gPhysics->createTriangleMesh(readBuffer);
+}
+
+
+// Parses .obj and loads it into two arrays
 bool ModelLoader::loadOBJ() {
     ifstream inFile;
 
-    inFile.open("C:\\UCF\\Senior Design\\Simulations\\Models\\Terrain\\84 South Project V2\\84S\\84SMosaic_Punchout_100mpp.obj");
+    // Put this model in a folder titled "Models" in the base
+    // of the repository.
+    inFile.open("../../../Models/AmundsenRim_100mpp.obj");
 
-    char buffer[512];
     string line;
-    
     if (getline(inFile, line)) {
         cout << "successfully opened .obj file" << endl;
     }
     else {
         cout << "failed to read file" << endl;
+        return false;
     }
 
     cout << "Reading .obj file...\n";
     while (!inFile.eof()) {
         getline(inFile, line);
         stringstream ss(line);
-        PxVec3d v;
+        PxVec3 v;
         string s;
         vector<unsigned> f;
         ss >> s;
 
         if (s == "v") {
             ss >> v[0] >> v[1] >> v[2];
-            vecv.push_back(v);
-        }
-        else if (s == "vn") {
-            ss >> v[0] >> v[1] >> v[2];
-            vecn.push_back(v);
+            vecv.pushBack(v);
         }
         else if (s == "f") {
-            vector<unsigned> temp(9, 0);
             char* stemp;
 
+            // Loading in only the vertex indicies
+            // cause PhysX doesn't care about normals
             for (int i = 0; i < 3; ++i) {
                 ss >> s;
-                // cout << s << endl;
                 stemp = (char*)s.c_str();
                 stemp = strtok(stemp, "/");
-
-                int ctr = 0;
-                while (stemp != NULL) {
-                    temp[i * 3 + ctr] = atoi(stemp);
-                    stemp = strtok(NULL, "/");
-                    ctr += 2;
-                }
+                vecf.pushBack(atoi(stemp));
             }
-
-            vecf.push_back(temp);
         }
     }
-
     inFile.close();
-    cout << "final vertex count: " << vecv.size() << endl;
-    cout << "final normal count: " << vecn.size() << endl;
-    cout << "final face count: "   << vecf.size() << endl;
 
     cout << "Finished reading .obj\n";
     return true;

--- a/Federation/Federates/CraterTransport/src/ModelLoader.h
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.h
@@ -16,6 +16,7 @@ using namespace std;
 class ModelLoader {
 public:
     PxTriangleMesh* loadCraterMesh(PxPhysics *gPhysics);
+    PxTriangleMesh* loadSampleCubeMesh(PxPhysics* gPhysics);
 
 private:
     bool loadOBJ();
@@ -23,12 +24,9 @@ private:
     PxTriangleMeshDesc meshDesc;
 
     // List of points (3D vectors)
-    vector<PxVec3d> vecv;
+    PxArray<PxVec3> vecv;
 
-    // List of normals (also 3D vectors)
-    vector<PxVec3d> vecn;
-
-    // list of faces (indices for vecv and vecn)
-    vector<vector<unsigned>> vecf;
+    // list of faces (indices for vecv)
+    PxArray<PxU32> vecf;
 };
 #endif

--- a/Federation/Federates/CraterTransport/src/ModelLoader.h
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.h
@@ -23,10 +23,10 @@ private:
     PxTriangleMeshDesc meshDesc;
 
     // List of points (3D vectors)
-    vector<PxVec3> vecv;
+    vector<PxVec3d> vecv;
 
     // List of normals (also 3D vectors)
-    vector<PxVec3> vecn;
+    vector<PxVec3d> vecn;
 
     // list of faces (indices for vecv and vecn)
     vector<vector<unsigned>> vecf;

--- a/Federation/Federates/CraterTransport/src/ModelLoader.h
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.h
@@ -20,6 +20,7 @@ public:
 
 private:
     bool loadOBJ();
+    inline bool fileExists(const std::string& name);
 
     PxTriangleMeshDesc meshDesc;
 

--- a/Federation/Federates/CraterTransport/src/ModelLoader.h
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#ifndef MODELLOADER_H
+#define MODELLOADER_H
+
+#include <PhysX/PxPhysicsAPI.h>
+
+#include <vector>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+using namespace physx;
+using namespace std;
+
+class ModelLoader {
+public:
+    PxTriangleMesh* loadCraterMesh(PxPhysics *gPhysics);
+
+private:
+    bool loadOBJ();
+
+    PxTriangleMeshDesc meshDesc;
+
+    // List of points (3D vectors)
+    vector<PxVec3> vecv;
+
+    // List of normals (also 3D vectors)
+    vector<PxVec3> vecn;
+
+    // list of faces (indices for vecv and vecn)
+    vector<vector<unsigned>> vecf;
+};
+#endif

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
@@ -8,7 +8,7 @@ namespace Physics {
     }
 
     PhysicsManager::~PhysicsManager() {
-
+        delete this;
     }
 
     bool PhysicsManager::initPhysics() {
@@ -54,6 +54,7 @@ namespace Physics {
         gScene->addActor(*groundPlane);
 
         defaultActor = createDynamic(PxTransform(PxVec3(0, 40, 100)), PxSphereGeometry(10), PxVec3(0, -50, -100));
+
     }
 
     void PhysicsManager::loadSampleEntryScene() {
@@ -66,9 +67,14 @@ namespace Physics {
 
         gMaterial = gPhysics->createMaterial(0.5f, 0.5f, 0.5f);
 
-        PxVec3 planeNormal = PxVec3(1.0f, 1.0f, 0.0f).getNormalized(); // PxPlane requires normalized vector
-        PxRigidStatic* groundPlane = PxCreatePlane(*gPhysics, PxPlane(planeNormal, 0), *gMaterial);
-        gScene->addActor(*groundPlane);
+        ModelLoader* obj = new ModelLoader();
+        PxTriangleMesh* moonMesh = obj->loadCraterMesh(gPhysics);
+        PxTriangleMeshGeometry moonMeshHandler(moonMesh);
+
+        PxRigidStatic* groundActor = gPhysics->createRigidStatic(PxTransform(PxIdentity));
+        PxShape* moonShape = PxRigidActorExt::createExclusiveShape(*groundActor, moonMeshHandler, *gMaterial, PxShapeFlag::eSIMULATION_SHAPE);
+        groundActor->attachShape(*moonShape);
+        gScene->addActor(*groundActor);
 
         defaultActor = createDynamic(PxTransform(PxVec3(0, 2, 2)), PxBoxGeometry(PxVec3(1.0f, 1.0f, 1.0f)), PxVec3(0, 0, 0));
     }

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
@@ -53,8 +53,8 @@ namespace Physics {
         PxRigidStatic* groundPlane = PxCreatePlane(*gPhysics, PxPlane(0, 1, 0, 0), *gMaterial);
         gScene->addActor(*groundPlane);
 
-        defaultActor = createDynamic(PxTransform(PxVec3(0, 40, 100)), PxSphereGeometry(10), PxVec3(0, -50, -100));
-
+        // Create the dynamic cube used in our samples
+        createDynamic(PxTransform(PxVec3(0, 40, 100)), PxSphereGeometry(10), PxVec3(0, -50, -100));
     }
 
     void PhysicsManager::loadSampleEntryScene() {
@@ -63,20 +63,25 @@ namespace Physics {
         gDispatcher = PxDefaultCpuDispatcherCreate(2);
         sceneDesc.cpuDispatcher = gDispatcher;
         sceneDesc.filterShader = PxDefaultSimulationFilterShader;
-        gScene = gPhysics->createScene(sceneDesc);
 
+        gScene = gPhysics->createScene(sceneDesc);
         gMaterial = gPhysics->createMaterial(0.5f, 0.5f, 0.5f);
 
+        // Loads triangle mesh
         ModelLoader* obj = new ModelLoader();
         PxTriangleMesh* moonMesh = obj->loadCraterMesh(gPhysics);
-        PxTriangleMeshGeometry moonMeshHandler(moonMesh);
 
-        PxRigidStatic* groundActor = gPhysics->createRigidStatic(PxTransform(PxIdentity));
-        PxShape* moonShape = PxRigidActorExt::createExclusiveShape(*groundActor, moonMeshHandler, *gMaterial, PxShapeFlag::eSIMULATION_SHAPE);
-        groundActor->attachShape(*moonShape);
+        if (moonMesh == NULL) {
+            return;
+        }
+
+        PxTriangleMeshGeometry moonMeshHandler(moonMesh);
+        PxRigidStatic* groundActor = gPhysics->createRigidStatic(PxTransform(PxVec3(0.0f, 0.0f, 0.0f)));
+        PxRigidActorExt::createExclusiveShape(*groundActor, moonMeshHandler, *gMaterial, PxShapeFlag::eSIMULATION_SHAPE);
         gScene->addActor(*groundActor);
 
-        defaultActor = createDynamic(PxTransform(PxVec3(0, 2, 2)), PxBoxGeometry(PxVec3(1.0f, 1.0f, 1.0f)), PxVec3(0, 0, 0));
+        // Create the dynamic cube used in our samples
+        createDynamic(PxTransform(PxVec3(0, 5, 2)), PxBoxGeometry(PxVec3(1.0f, 1.0f, 1.0f)), PxVec3(0, 0, 0));
     }
 
     void PhysicsManager::simulateStep(double timeStep) {

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
@@ -81,7 +81,7 @@ namespace Physics {
         gScene->addActor(*groundActor);
 
         // Create the dynamic cube used in our samples
-        createDynamic(PxTransform(PxVec3(0, 5, 2)), PxBoxGeometry(PxVec3(1.0f, 1.0f, 1.0f)), PxVec3(0, 0, 0));
+        createDynamic(PxTransform(PxVec3(0, 5, 0)), PxBoxGeometry(PxVec3(1.0f, 1.0f, 1.0f)), PxVec3(0, 0, 0));
     }
 
     void PhysicsManager::simulateStep(double timeStep) {

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.h
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.h
@@ -49,7 +49,6 @@ namespace Physics {
     private:
         PxDefaultAllocator       gAllocator;
         PxDefaultErrorCallback   gErrorCallback;
-        PxRigidDynamic*          defaultActor = nullptr;
         PxFoundation*            gFoundation = nullptr;
         PxPhysics*               gPhysics = nullptr;
         PxDefaultCpuDispatcher*  gDispatcher = nullptr;

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.h
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.h
@@ -5,6 +5,7 @@
 #include <PhysX/PxPhysicsAPI.h>
 
 #include "OmniPvd.h"
+#include "ModelLoader.h"
 
 using namespace physx;
 


### PR DESCRIPTION
- Added a .obj parser that can load in the crater environments for use in the PhysX simulation.
- The models can't be provided on the repo but if you have them store them in a "Models" folder in the root folder of the repo.
- Depending on the size of the object file it can take a while to load in, especially in debug mode.