### PR TITLE
Small merge request

### DIFF
--- a/Federation/Federates/CraterTransport/src/ModelLoader.cpp
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.cpp
@@ -1,11 +1,11 @@
 #include "ModelLoader.h"
 
-PxTriangleMesh* ModelLoader::loadCraterMesh(PxPhysics* gPhysics) {
+PxTriangleMesh* ModelLoader::loadMesh(PxPhysics* gPhysics, string filepath) {
     bool status;
 
     // Attempt to open the specified crater mesh file
-    if (fileExists("../../../Models/AmundsenRim_100mpp_triangulated.obj")) {
-        status = loadOBJ();
+    if (fileExists(filepath)) {
+        status = loadOBJ(filepath);
     }
     else {
         cout << "Couldn't open crater model, loading sample cube mesh instead.\n\n";
@@ -153,12 +153,12 @@ PxTriangleMesh* ModelLoader::loadSampleCubeMesh(PxPhysics* gPhysics) {
 }
 
 // Parses .obj and loads it into two arrays
-bool ModelLoader::loadOBJ() {
+bool ModelLoader::loadOBJ(string filepath) {
     ifstream inFile;
 
     // Put this model in a folder titled "Models" in the base
     // of the repository.
-    inFile.open("../../../Models/shackleton_highres_triangulated_scaled.obj");
+    inFile.open(filepath);
 
     string line;
 

--- a/Federation/Federates/CraterTransport/src/ModelLoader.h
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.h
@@ -15,11 +15,11 @@ using namespace std;
 
 class ModelLoader {
 public:
-    PxTriangleMesh* loadCraterMesh(PxPhysics *gPhysics);
+    PxTriangleMesh* loadMesh(PxPhysics *gPhysics, string filepath);
     PxTriangleMesh* loadSampleCubeMesh(PxPhysics* gPhysics);
 
 private:
-    bool loadOBJ();
+    bool loadOBJ(string filepath);
     inline bool fileExists(const std::string& name);
 
     PxTriangleMeshDesc meshDesc;

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
@@ -70,7 +70,7 @@ namespace Physics {
 
         // Loads triangle mesh
         ModelLoader* obj = new ModelLoader();
-        PxTriangleMesh* moonMesh = obj->loadCraterMesh(gPhysics);
+        PxTriangleMesh* moonMesh = obj->loadMesh(gPhysics, "../../../Models/AmundsenRim_100mpp_triangulated.obj");
 
         if (moonMesh == NULL) {
             return;


### PR DESCRIPTION
Genralized loadCraterMesh() to load any mesh and also made it so it takes in a filepath instead of hard-coding it.