### PR TITLE
Packaged launcher model

### DIFF
--- a/Federation/Federates/CraterTransport/src/ModelLoader.cpp
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.cpp
@@ -1,6 +1,6 @@
 #include "ModelLoader.h"
 
-PxTriangleMesh* ModelLoader::loadMesh(PxPhysics* gPhysics, string filepath) {
+PxTriangleMesh* ModelLoader::loadMesh(PxPhysics* gPhysics, string filepath, bool createSDF) {
     bool status;
 
     // Attempt to open the specified crater mesh file
@@ -30,15 +30,30 @@ PxTriangleMesh* ModelLoader::loadMesh(PxPhysics* gPhysics, string filepath) {
     meshDesc.triangles.data = vecf.begin();
     meshDesc.triangles.stride = 3 * sizeof(PxU32);
     
+    if (createSDF) {
+        PxSDFDesc sdfDesc;
+        sdfDesc.spacing = 0.05f;
+        sdfDesc.subgridSize = 6;
+        sdfDesc.bitsPerSubgridPixel = PxSdfBitsPerSubgridPixel::e16_BIT_PER_PIXEL;
+        sdfDesc.numThreadsForSdfConstruction = 8;
+
+        meshDesc.sdfDesc = &sdfDesc;
+    }
+
     PxTolerancesScale scale;
     PxCookingParams params(scale);
+
+    params.meshWeldTolerance = 0.001f;
+    params.meshPreprocessParams = PxMeshPreprocessingFlags(PxMeshPreprocessingFlag::eWELD_VERTICES);
+    params.buildTriangleAdjacencies = false;
+    params.buildGPUData = true;
 
     // Structure used for fast collision calculations
     params.midphaseDesc = PxMeshMidPhase::eBVH33;
     params.suppressTriangleMeshRemapTable = true;
 
-    params.meshPreprocessParams &= PxMeshPreprocessingFlag::eDISABLE_CLEAN_MESH;
-    params.meshPreprocessParams &= PxMeshPreprocessingFlag::eDISABLE_ACTIVE_EDGES_PRECOMPUTE;
+    //params.meshPreprocessParams &= PxMeshPreprocessingFlag::eDISABLE_CLEAN_MESH;
+    //params.meshPreprocessParams &= PxMeshPreprocessingFlag::eDISABLE_ACTIVE_EDGES_PRECOMPUTE;
 
     // Value between 0 and 1 used to determine how much of the mesh is cooked before
     // simulation start

--- a/Federation/Federates/CraterTransport/src/ModelLoader.cpp
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.cpp
@@ -8,7 +8,7 @@ PxTriangleMesh* ModelLoader::loadMesh(PxPhysics* gPhysics, string filepath) {
         status = loadOBJ(filepath);
     }
     else {
-        cout << "Couldn't open crater model, loading sample cube mesh instead.\n\n";
+        cout << "Couldn't open model, loading sample cube mesh instead.\n\n";
         return loadSampleCubeMesh(gPhysics);
     }
 

--- a/Federation/Federates/CraterTransport/src/ModelLoader.h
+++ b/Federation/Federates/CraterTransport/src/ModelLoader.h
@@ -15,7 +15,7 @@ using namespace std;
 
 class ModelLoader {
 public:
-    PxTriangleMesh* loadMesh(PxPhysics *gPhysics, string filepath);
+    PxTriangleMesh* loadMesh(PxPhysics *gPhysics, string filepath, bool createSDF = false);
     PxTriangleMesh* loadSampleCubeMesh(PxPhysics* gPhysics);
 
 private:

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
@@ -69,8 +69,9 @@ namespace Physics {
         gMaterial = gPhysics->createMaterial(0.1f, 0.1f, 0.1f);
 
         // Loads triangle mesh
-        ModelLoader* obj = new ModelLoader();
-        PxTriangleMesh* moonMesh = obj->loadMesh(gPhysics, "../../../Models/shackleton_highres_triangulated_scaled.obj");
+        ModelLoader* moonLoader = new ModelLoader();
+
+        PxTriangleMesh* moonMesh = moonLoader->loadMesh(gPhysics, "../../../Models/shackleton_highres_triangulated_scaled.obj");
 
         if (moonMesh == NULL) {
             return;
@@ -84,11 +85,28 @@ namespace Physics {
         PxRigidStatic* groundActor = gPhysics->createRigidStatic(PxTransform(PxVec3(0.0f, 0.0f, 0.0f)));
         PxRigidActorExt::createExclusiveShape(*groundActor, moonMeshHandler, *gMaterial, PxShapeFlag::eSIMULATION_SHAPE);
 
-        gScene->addActor(*groundActor);
         groundActor->setGlobalPose(PxTransform(PxVec3(0.0f, 0.0f, 0.0f), PxQuat(PxDegToRad(-0.0f), PxVec3(0.0f, 0.0f, 1.0f))));
+        gScene->addActor(*groundActor);
+        
+        ModelLoader* launcherLoader = new ModelLoader();
+        PxTriangleMesh* launcherMesh = launcherLoader->loadMesh(gPhysics, "../../../Models/SledCrateExport.obj");
+        
+        if (launcherMesh == NULL) {
+            return;
+        }
+
+        PxTriangleMeshGeometry launcherMeshHandler(launcherMesh);
+
+        PxRigidDynamic* launcherActor = gPhysics->createRigidDynamic(PxTransform(PxVec3(0.0f, 0.0f, 0.0f)));
+        launcherActor->setRigidBodyFlag(PxRigidBodyFlag::eKINEMATIC, true);
+        PxRigidActorExt::createExclusiveShape(*launcherActor, launcherMeshHandler, *gMaterial, PxShapeFlag::eSIMULATION_SHAPE);
+
+        launcherActor->setGlobalPose(PxTransform(PxVec3(246.12082f, 1300.63616f, 216.73205f)));
+        gScene->addActor(*launcherActor);
+
 
         // Create the dynamic cube used in our samples using a hard-coded starting position to ensure deterministic outcome
-        createDynamic(PxTransform(PxVec3(246.12082f, 1300.63616f, 216.73205f)), PxBoxGeometry(PxVec3(1.0f, 1.0f, 1.0f)), PxVec3(0, 0, 0));
+        // createDynamic(PxTransform(PxVec3(246.12082f, 1300.63616f, 216.73205f)), PxBoxGeometry(PxVec3(1.0f, 1.0f, 1.0f)), PxVec3(0, 0, 0));
     }
 
     // Moves the simulation by the specified time-step

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
@@ -70,7 +70,7 @@ namespace Physics {
 
         // Loads triangle mesh
         ModelLoader* obj = new ModelLoader();
-        PxTriangleMesh* moonMesh = obj->loadMesh(gPhysics, "../../../Models/AmundsenRim_100mpp_triangulated.obj");
+        PxTriangleMesh* moonMesh = obj->loadMesh(gPhysics, "../../../Models/shackleton_highres_triangulated_scaled.obj");
 
         if (moonMesh == NULL) {
             return;

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
@@ -165,6 +165,7 @@ namespace Physics {
         PX_RELEASE(gPhysics);
         PX_RELEASE(gFoundation);
         PX_RELEASE(gOmniPvd);
+        PX_RELEASE(gCudaContextManager);
 
         printf("Simulation Complete\n");
     }
@@ -214,5 +215,9 @@ namespace Physics {
 
     const char* PhysicsManager::getOmniPvdPath() {
         return gOmniPvdPath;
+    }
+
+    const PxCudaContextManager* PhysicsManager::getCudaContextManager() {
+        return gCudaContextManager;
     }
 }

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
@@ -84,10 +84,6 @@ namespace Physics {
         ModelLoader* moonLoader = new ModelLoader();
 
         PxTriangleMesh* moonMesh = moonLoader->loadMesh(gPhysics, "../../../Models/shackleton_highres_triangulated_scaled.obj");
-
-        if (moonMesh == NULL) {
-            return;
-        }
         
         // Cooked triangle mesh neds to be stored in a separate handler
         // that has more robust functionality
@@ -102,11 +98,8 @@ namespace Physics {
         
         ModelLoader* launcherLoader = new ModelLoader();
         PxTriangleMesh* launcherMesh = launcherLoader->loadMesh(gPhysics, "../../../Models/SledCrateExport.obj", true);
-        
-        if (launcherMesh == NULL) {
-            return;
-        }
 
+        // Loading and setting up the sled model
         PxTriangleMeshGeometry launcherMeshHandler;
         launcherMeshHandler.triangleMesh = launcherMesh;
         launcherMeshHandler.scale = PxVec3(1.0f);

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
@@ -45,41 +45,7 @@ namespace Physics {
             return false;
         }
         #endif
-        
-        return true;
-    }
 
-    void PhysicsManager::loadSampleScene() {
-        PxSceneDesc sceneDesc(gPhysics->getTolerancesScale());
-        sceneDesc.gravity = PxVec3(0.0f, -1.62f, 0.0f);
-        gDispatcher = PxDefaultCpuDispatcherCreate(2);
-        sceneDesc.cpuDispatcher = gDispatcher;
-        sceneDesc.filterShader = PxDefaultSimulationFilterShader;
-        
-        if (!sceneDesc.cudaContextManager) {
-            sceneDesc.cudaContextManager = gCudaContextManager;
-        }
-
-        sceneDesc.flags |= PxSceneFlag::eENABLE_GPU_DYNAMICS;
-        sceneDesc.flags |= PxSceneFlag::eENABLE_PCM;
-
-        sceneDesc.broadPhaseType = PxBroadPhaseType::eGPU;
-        sceneDesc.gpuMaxNumPartitions = 8;
-
-        sceneDesc.solverType = PxSolverType::eTGS;
-
-        gScene = gPhysics->createScene(sceneDesc);
-
-        gMaterial = gPhysics->createMaterial(0.5f, 0.5f, 0.5f);
-
-        PxRigidStatic* groundPlane = PxCreatePlane(*gPhysics, PxPlane(0, 1, 0, 0), *gMaterial);
-        gScene->addActor(*groundPlane);
-
-        // Create the dynamic cube used in our samples
-        createDynamic(PxTransform(PxVec3(0, 40, 100)), PxSphereGeometry(10), PxVec3(0, -50, -100));
-    }
-
-    void PhysicsManager::loadSampleEntryScene() {
         // Base parameters for the PhysX scene
         PxSceneDesc sceneDesc(gPhysics->getTolerancesScale());
         sceneDesc.gravity = PxVec3(0.0f, -1.62f, 0.0f);
@@ -100,10 +66,20 @@ namespace Physics {
         sceneDesc.solverType = PxSolverType::eTGS;
 
         gScene = gPhysics->createScene(sceneDesc);
-
-        gScene = gPhysics->createScene(sceneDesc);
         gMaterial = gPhysics->createMaterial(0.1f, 0.1f, 0.1f);
+        
+        return true;
+    }
 
+    void PhysicsManager::loadSampleScene() {
+        PxRigidStatic* groundPlane = PxCreatePlane(*gPhysics, PxPlane(0, 1, 0, 0), *gMaterial);
+        gScene->addActor(*groundPlane);
+
+        // Create the dynamic cube used in our samples
+        createDynamic(PxTransform(PxVec3(0, 40, 100)), PxSphereGeometry(10), PxVec3(0, -50, -100));
+    }
+
+    void PhysicsManager::loadSampleEntryScene() {
         // Loads triangle mesh
         ModelLoader* moonLoader = new ModelLoader();
 

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.cpp
@@ -80,7 +80,7 @@ namespace Physics {
     }
 
     void PhysicsManager::loadSampleEntryScene() {
-        // Loads triangle mesh
+        // Loads the moon environment model
         ModelLoader* moonLoader = new ModelLoader();
 
         PxTriangleMesh* moonMesh = moonLoader->loadMesh(gPhysics, "../../../Models/shackleton_highres_triangulated_scaled.obj");
@@ -89,37 +89,54 @@ namespace Physics {
         // that has more robust functionality
         PxTriangleMeshGeometry moonMeshHandler(moonMesh);
 
+        // Temporary material property for the crater environment (NEEDS UPDATE)
+        PxMaterial* moonMaterial = gPhysics->createMaterial(0.1f, 0.1f, 0.1f);
+
         // Creating the rigid actor which will hold the moon crater mesh
         PxRigidStatic* groundActor = gPhysics->createRigidStatic(PxTransform(PxVec3(0.0f, 0.0f, 0.0f)));
-        PxRigidActorExt::createExclusiveShape(*groundActor, moonMeshHandler, *gMaterial, PxShapeFlag::eSIMULATION_SHAPE);
+        PxRigidActorExt::createExclusiveShape(*groundActor, moonMeshHandler, *moonMaterial, PxShapeFlag::eSIMULATION_SHAPE);
 
-        groundActor->setGlobalPose(PxTransform(PxVec3(0.0f, 0.0f, 0.0f), PxQuat(PxDegToRad(-0.0f), PxVec3(0.0f, 0.0f, 1.0f))));
+        groundActor->setGlobalPose(PxTransform(PxVec3(0.0f, 0.0f, 0.0f)));
         gScene->addActor(*groundActor);
         
         ModelLoader* launcherLoader = new ModelLoader();
         PxTriangleMesh* launcherMesh = launcherLoader->loadMesh(gPhysics, "../../../Models/SledCrateExport.obj", true);
 
+        // -------------------------------------------------------------------------------------------------------------
         // Loading and setting up the sled model
         PxTriangleMeshGeometry launcherMeshHandler;
         launcherMeshHandler.triangleMesh = launcherMesh;
         launcherMeshHandler.scale = PxVec3(1.0f);
 
         PxRigidDynamic* launcherActor = gPhysics->createRigidDynamic(PxTransform(PxVec3(0.0f, 0.0f, 0.0f)));
+
+        // Damping values
         launcherActor->setLinearDamping(0.2f);
         launcherActor->setAngularDamping(0.1f);
+
+        // Setting collision related flags
         launcherActor->setRigidBodyFlag(PxRigidBodyFlag::eENABLE_GYROSCOPIC_FORCES, true);
         launcherActor->setRigidBodyFlag(PxRigidBodyFlag::eENABLE_SPECULATIVE_CCD, true);
-        PxShape* launcherShape = PxRigidActorExt::createExclusiveShape(*launcherActor, launcherMeshHandler, *gMaterial);
+
+        // Temporary material property for the sled (NEEDS UPDATE)
+        PxMaterial* launcherMaterial = gPhysics->createMaterial(0.1f, 0.1f, 0.1f);
+
+        PxShape* launcherShape = PxRigidActorExt::createExclusiveShape(*launcherActor, launcherMeshHandler, *launcherMaterial);
+
+        // Offset from created SDF for collision resolution
         launcherShape->setContactOffset(0.1f);
         launcherShape->setRestOffset(0.02f);
 
+        // Setting mass and density values, mass not currently being set (default 1)
         PxReal density = 100.0f;
         PxRigidBodyExt::updateMassAndInertia(*launcherActor, density);
 
         gScene->addActor(*launcherActor);
+
+        // Custom settings
         launcherActor->setSolverIterationCounts(50, 1);
         launcherActor->setMaxDepenetrationVelocity(5.0f);
-        launcherActor->setGlobalPose(PxTransform(PxVec3(246.12082f, 1300.63616f, 216.73205f)));
+        launcherActor->setGlobalPose(PxTransform(PxVec3(246.12082f, 1300.63616f, 216.73205f), PxQuat(PxPi, PxVec3(0.0f, 1.0f, 0.0f))));
     }
 
     // Moves the simulation by the specified time-step

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.h
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.h
@@ -55,6 +55,7 @@ namespace Physics {
         PxScene*                 gScene = nullptr;
         PxMaterial*              gMaterial = nullptr;
         PxOmniPvd*               gOmniPvd = nullptr;
+        PxCudaContextManager*    gCudaContextManager = nullptr;
         const char*              gOmniPvdPath = nullptr;
     };
 }

--- a/Federation/Federates/CraterTransport/src/PhysicsManager.h
+++ b/Federation/Federates/CraterTransport/src/PhysicsManager.h
@@ -44,6 +44,7 @@ namespace Physics {
         const PxMaterial* getMaterial();
         const PxOmniPvd* getOmniPvd();
         const char* getOmniPvdPath();
+        const PxCudaContextManager* getCudaContextManager();
 
         PxRigidDynamic* createDynamic(const PxTransform& t, const PxGeometry& geometry, const PxVec3& velocity = PxVec3(0));
     private:


### PR DESCRIPTION
The main goal of the branch was to add the packaged launcher and sled model to the simulation so that it can replace the cube, but a lot of work needed to be done beforehand for that to happen. I'll list the changes in a bullet point format below, and explain my reasoning where I it may be useful.

- Changed the loadObj and loadCraterMesh models to use a filepath instead of the hardcoded path it was using before so that we could also load in the sled model.
- Dynamic objects cannot be standard triangle meshes in PhysX because there is no way to calculate collisions for them, so I had to create a signed-distance field (SDF) for the sled triangle mesh in order for that to work.
- In order for SDFs to work as dynamic objects, they need to be able to run on the GPU. So, I had to add GPU capabilities to our PhysX simulation. This doesn't change much and if anything should speed up some of the complex collision calculations being done, but it does require the addition of two more libraries into our debug and release folder, PhysXGpu_64 and PhysXDevice64.
- Moved the scene description code to initPhysics to avoid code duplication, doesn't change anything because all of our scenes will use the same basic scene description.
- Added comments to the new code, and made some miscellaneous changes to improve readability of the code.