### PR TITLE
Set up a preprocessor directive in our project to disable HLA

### DIFF
--- a/Federation/Federates/CraterTransport/CMakeLists.txt
+++ b/Federation/Federates/CraterTransport/CMakeLists.txt
@@ -1,5 +1,11 @@
 set(TARGET_NAME CraterTransport)
 
+# Option to run the code without using HLA to avoid errors and focusing only on the physics of the simulation
+option(USE_HLA "Choose whether to attempt an HLA connection when running the simulation" ON)
+if (USE_HLA)
+	add_compile_definitions(USE_HLA)
+endif()
+
 add_executable(${TARGET_NAME}
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/CraterTransport.cpp"
 	"${CMAKE_CURRENT_SOURCE_DIR}/src/PhysicsManager.h"

--- a/Federation/Federates/CraterTransport/src/CraterTransport.cpp
+++ b/Federation/Federates/CraterTransport/src/CraterTransport.cpp
@@ -11,7 +11,10 @@ using namespace LunarSimulation;
 int main(void) {
     // Creates federation if this is the first federate connected,
     // connects to existing federation otherwise
+    #if USE_HLA
     HlaWorldPtr hlaWorld = HlaWorld::Factory::create();
+    #endif
+
     Physics::PhysicsManager* physicsManager = new Physics::PhysicsManager();
 
     if (!physicsManager->initPhysics()) {
@@ -20,6 +23,7 @@ int main(void) {
 
     physicsManager->loadSampleEntryScene();
 
+    #if USE_HLA
     try {
         hlaWorld->connect();
     }
@@ -35,12 +39,14 @@ int main(void) {
     // Single Payload instance, extends Dynamical Entity and has a number
     // of functions to retrive its values such as acceleration and position
     HlaPayloadPtr payload = payloadManager->createLocalHlaPayload(L"Payload");
+    #endif
 
     // TODO: Find a stopping point for our federate
     while (true) {
         try {
             physicsManager->simulateStep();
 
+            #if USE_HLA
             // Manages variable/state changes and communicates them to the federation.
             // New instance must be created on every loop.
             HlaPayloadUpdaterPtr updater = payload->getHlaPayloadUpdater();
@@ -53,13 +59,16 @@ int main(void) {
             // Packages all state/variable changes and sends them out to the federation
             // where other federates can pull the new values in and use them as needed.
             updater->sendUpdate();
+            #endif
         }
         catch (std::exception& e) {
             // TODO Auto-generated catch block
             std::cout << e.what() << std::endl;
         }
 
+        #if USE_HLA
         hlaWorld->advanceToNextFrame();
+        #endif
     }
 
     physicsManager->cleanupPhysics();
@@ -67,5 +76,7 @@ int main(void) {
     // Here we will do all of the federate cleanup necessary after it has finished running.
     // Unfortunately we can't run this code right now because we don't have a valid stopping
     // condition for our main loop.
+    #if USE_HLA
     hlaWorld->disconnect();
+    #endif
 }


### PR DESCRIPTION
Added a CMake preprocessor directive that allows you to turn off all of the HLA code during build-time. You can build it by typing "make -DUSE_HLA=ON/OFF" or from the CMake GUI it'll be a checkbox. 